### PR TITLE
fix deprecated php 8.2 warning

### DIFF
--- a/src/Annotations/TagAnnotationReader.php
+++ b/src/Annotations/TagAnnotationReader.php
@@ -12,6 +12,9 @@ use ReflectionClass;
  */
 class TagAnnotationReader
 {
+    protected $class;
+    protected $callback;
+
     /**
      * @param string $class
      * @param callable $callback


### PR DESCRIPTION
Simple fix for php 8.2 complaining about the creation of dynamic properties